### PR TITLE
Toggle schedule_tasks flag in config

### DIFF
--- a/templates/config.inc.php.j2
+++ b/templates/config.inc.php.j2
@@ -44,7 +44,7 @@ session_lifetime = 30
 ; Enable support for running scheduled tasks
 ; Set this to On if you have set up the scheduled tasks script to
 ; execute periodically
-scheduled_tasks = Off
+scheduled_tasks = On
 
 ; Site time zone
 ; Please refer to lib/pkp/registry/timeZones.xml for a full list of supported

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -45,6 +45,9 @@
     location  ~ ^(.*)/ojs/?(.*)$ {
       try_files $uri $uri/ $1/ojs/index.php/$2$is_args$args;
     }
+    location ~ ^(.*)/public/site/?(.*)$ {
+      try_files $uri $1/ojs/public/site/$2;
+    }
   }
 {% endfor %}
 


### PR DESCRIPTION
Enable schedule_tasks in OJS

This is done by setting scheduled_tasks = On in config.inc.php; This allows scheduled reminders to authors/reviewers when a submission is overdue