### PR TITLE
Add try-files for public directory

### DIFF
--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -45,6 +45,11 @@
     location  ~ ^(.*)/ojs/?(.*)$ {
       try_files $uri $uri/ $1/ojs/index.php/$2$is_args$args;
     }
+ 
+    # Try files for public directory
+    location ~ ^(.*)/public/site/?(.*)$ {
+      try_files $uri $1/ojs/public/site/$2;
+    }
   }
 {% endfor %}
 


### PR DESCRIPTION
Upon user reporting issue that they cannot view uploaded user files, which reside in {OJS-SITE}/public/ it was found that NGINX was not looking in said directory for those files.

This has been tested on a development instance of OJS3. 