### PR TITLE
3.2

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 
 # We'll end up fetching
 # {{ ojs_download_url }}{{ ojs_tarball }}
-sclphp_version: "rh-php72"
+min_php_version: "72"
 sclphp_location: "/opt/rh/{{sclphp_version}}/root/usr/bin/php"
 ojs_version: "3.2.0"
 ojs_md5sum: "90c9a9da9025a5a2878c740ce6df3d2c"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,15 +3,19 @@
 
 # We'll end up fetching
 # {{ ojs_download_url }}{{ ojs_tarball }}
-ojs_version: "3.1.0-1"
-ojs_md5sum: "fcb665e19ae25c204c3ddc7efa86d232"
+sclphp_version: "rh-php72"
+sclphp_location: "/opt/rh/{{sclphp_version}}/root/usr/bin/php"
+ojs_version: "3.2.0"
+ojs_md5sum: "90c9a9da9025a5a2878c740ce6df3d2c"
 ojs_download_url: "http://pkp.sfu.ca/ojs/download/"
 ojs_tarball: "ojs-{{ ojs_version }}.tar.gz"
+ojs_md5sum: "b9baca4ea156b2142e233be113ea631a"
+ojs_download_url: "http://pkp.sfu.ca/ojs/download/"
+ojs_tarball: "ojs-{{ ojs_version }}.tar.gz"
+ojs_bootstrap_url: "https://github.com/NateWr/bootstrap3/releases/download/3.2.0/"
+ojs_bootstrap_tarball: "bootstrap3-3.2.0.0.tar.gz"
 
-ojs_bootstrap_version: "v1.1.0.0"
-ojs_bootstrap_md5sum: "ed67d475f7a59d46387b5bfa1a8a2a28"
-ojs_bootstrap_url: "https://github.com/NateWr/bootstrap3/releases/download/1.1/"
-ojs_bootstrap_tarball: "bootstrap3-{{ ojs_bootstrap_version }}.tar.gz"
+ojs_bootstrap_md5sum: "c3d1efa61915f532745e83efe53c27fc"
 
 ojs_parent_dir: "/srv"
 ojs_envelope_sender: "lib-noreply@ou.edu"

--- a/tasks/assets.yml
+++ b/tasks/assets.yml
@@ -1,4 +1,17 @@
 ---
+# Download required packages and tarballs
+- name: Download OJS tarball
+  get_url:
+    url: "{{ ojs_download_url }}{{ ojs_tarball }}"
+    dest: "/tmp/{{ ojs_tarball }}"
+    checksum: "md5:{{ ojs_md5sum }}"
+
+- name: Download  OJS Bootstrap Theme tarball
+  get_url:
+    url: "{{ ojs_bootstrap_url }}{{ ojs_bootstrap_tarball }}"
+    dest: "/tmp/{{ ojs_bootstrap_tarball }}"
+    checksum: "md5:{{ ojs_bootstrap_md5sum }}"
+
 - name: Ensure /opt/oulib/ojs/bin exists
   file:
     path: /opt/oulib/ojs/bin

--- a/tasks/deploy_src.yml
+++ b/tasks/deploy_src.yml
@@ -1,4 +1,19 @@
 ---
+- name: Check for current OJS code to site
+  stat:
+    path: "{{ item }}/ojs"
+  register: ojs_code
+
+- name: Set current version
+  set_fact:
+   current_version: "{{ ojs_code.stat.lnk_source | basename | regex_replace('ojs-', '') }}"
+  when: ojs_code.stat.lnk_source is defined
+
+- name: Clean current version
+  set_fact:
+   current_version: "{{ current_version.split('-') | join('.') }}"
+  when: ojs_code.stat.lnk_source is defined
+
 - name: Deploy OJS code to site
   unarchive:
     src: "/tmp/{{ ojs_tarball }}"
@@ -24,6 +39,9 @@
     - name: Copy files from ojs/public to public
       command: >
         rsync --recursive --times --ignore-existing "{{ item }}/ojs-{{ ojs_version }}/public/" "{{ item }}/public"
+    - name: Copy Themes from previous install
+      command: >
+        rsync --ignore-existing --recursive "{{ ojs_code.stat.lnk_source }}/plugins/themes/" "{{ item }}/ojs-{{ ojs_version }}/plugins/themes/"
     - name: Remove public from ojs dist folder
       file:
         path: "{{ item }}/ojs-{{ ojs_version }}/public"
@@ -47,10 +65,7 @@
         src: "{{ item }}/ojs-{{ ojs_version }}"
         path: "{{ item }}/ojs"
         state: link
-    - name: Copy Themes from previous install
-      command: >
-        rsync --ignore-existing --recursive "{{ ojs_code.stat.lnk_source }}/plugins/themes/" "{{ item }}/ojs-{{ ojs_version }}/plugins/themes/"
-  when: deploy_ojs_code.changed  
+      when: deploy_ojs_code.changed  
 
 
 - name: Set SELinux context for etc subdirectory

--- a/tasks/deploy_src.yml
+++ b/tasks/deploy_src.yml
@@ -59,6 +59,9 @@
         src: "{{ item }}/ojs-{{ ojs_version }}"
         path: "{{ item }}/ojs"
         state: link
+    - name: Copy Themes from previous install
+      command: >
+        rsync --ignore-existing --recursive "{{ ojs_code.stat.lnk_source }}/plugins/themes/" "{{ item }}/ojs-{{ ojs_version }}/plugins/themes/"
   when: deploy_ojs_code.changed  
 
 

--- a/tasks/deploy_src.yml
+++ b/tasks/deploy_src.yml
@@ -1,10 +1,4 @@
 ---
-- name: Download OJS tarball
-  get_url:
-    url: "{{ ojs_download_url }}{{ ojs_tarball }}"
-    dest: "/tmp/{{ ojs_tarball }}"
-    checksum: "md5:{{ ojs_md5sum }}"
-
 - name: Deploy OJS code to site
   unarchive:
     src: "/tmp/{{ ojs_tarball }}"
@@ -14,12 +8,6 @@
     group: nginx
     copy: no
   register: deploy_ojs_code  
-
-- name: Download  OJS Bootstrap Theme tarball
-  get_url:
-    url: "{{ ojs_bootstrap_url }}{{ ojs_bootstrap_tarball }}"
-    dest: "/tmp/{{ ojs_bootstrap_tarball }}"
-    checksum: "md5:{{ ojs_bootstrap_md5sum }}"
 
 - name: Deploy OJS Bootstrap Theme
   unarchive:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 
 # Install OJS-specific requirements
+- include: pre_tasks.yml
+  become: true
+  tags: [ ojs_pre_tasks, upgrade ] 
+
 - include: yum.yml
   become: true
   tags: ojs_yum

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,29 +1,31 @@
 ---
 
-# Install OJS-specific requirements
-- include: pre_tasks.yml
-  become: true
-  tags: [ ojs_pre_tasks, upgrade ] 
+- name: Get package facts
+  package_facts:
+    manager: rpm
 
-- include: yum.yml
-  become: true
-  tags: ojs_yum
-
-# Place supporting scripts and files          
-- include: assets.yml
-  become: true
-  tags: ojs_assets
-
-# Download and install OJS for sites          
-- include: deploy.yml
-  become: true
-  tags: [ ojs_deploy, upgrade ]
-
-# Configure nginx for OJS sites
-- include: nginx.yml
-  become: true
-  tags: ojs_nginx
-
-- include: upgrade.yml
-  become: true
-  tags: [ never, upgrade ]
+- name: Run playbook
+  block: 
+  - include: yum.yml
+    become: true
+    tags: ojs_yum
+  
+  # Place supporting scripts and files          
+  - include: assets.yml
+    become: true
+    tags: ojs_assets
+  
+  # Download and install OJS for sites          
+  - include: deploy.yml
+    become: true
+    tags: [ ojs_deploy, upgrade ]
+  
+  # Configure nginx for OJS sites
+  - include: nginx.yml
+    become: true
+    tags: ojs_nginx
+  
+  - include: upgrade.yml
+    become: true
+    tags: [ never, upgrade ]
+  when: "ansible_facts.packages['{{ min_php_version }}'] is defined"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,13 +20,14 @@
 # Download and install OJS for sites          
 - include: deploy.yml
   become: true
-  tags: [ ojs_deploy, upgrade ]
+  tags: ojs_deploy
 
 # Configure nginx for OJS sites
 - include: nginx.yml
   become: true
   tags: ojs_nginx
 
+# Run upgrade tool 
 - include: upgrade.yml
   become: true
-  tags: [ never, upgrade ]
+  tags: upgrade

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,31 +1,32 @@
 ---
 
-- name: Get package facts
-  package_facts:
-    manager: rpm
+- set_fact:
+    sn: "{{ sclphp_version | regex_replace('rh-php', '') }}"
+    mn: "{{ min_php_version | regex_replace('rh-php', '') }}"
 
-- name: Run playbook
-  block: 
-  - include: yum.yml
-    become: true
-    tags: ojs_yum
-  
-  # Place supporting scripts and files          
-  - include: assets.yml
-    become: true
-    tags: ojs_assets
-  
-  # Download and install OJS for sites          
-  - include: deploy.yml
-    become: true
-    tags: [ ojs_deploy, upgrade ]
-  
-  # Configure nginx for OJS sites
-  - include: nginx.yml
-    become: true
-    tags: ojs_nginx
-  
-  - include: upgrade.yml
-    become: true
-    tags: [ never, upgrade ]
-  when: "ansible_facts.packages['{{ min_php_version }}'] is defined"
+- fail:
+    msg: "Minimum PHP Requirement not met: =>{{ min_php_version }}"
+  when: sn is version(mn, "<")
+
+- include: yum.yml
+  become: true
+  tags: ojs_yum
+
+# Place supporting scripts and files          
+- include: assets.yml
+  become: true
+  tags: ojs_assets
+
+# Download and install OJS for sites          
+- include: deploy.yml
+  become: true
+  tags: [ ojs_deploy, upgrade ]
+
+# Configure nginx for OJS sites
+- include: nginx.yml
+  become: true
+  tags: ojs_nginx
+
+- include: upgrade.yml
+  become: true
+  tags: [ never, upgrade ]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,9 +13,13 @@
 # Download and install OJS for sites          
 - include: deploy.yml
   become: true
-  tags: ojs_deploy
+  tags: [ ojs_deploy, upgrade ]
 
 # Configure nginx for OJS sites
 - include: nginx.yml
   become: true
   tags: ojs_nginx
+
+- include: upgrade.yml
+  become: true
+  tags: [ never, upgrade ]

--- a/tasks/pre_tasks.yml
+++ b/tasks/pre_tasks.yml
@@ -1,0 +1,17 @@
+---
+
+# Check PHP Requirements
+
+# Download required packages and tarballs
+- name: Download OJS tarball
+  get_url:
+    url: "{{ ojs_download_url }}{{ ojs_tarball }}"
+    dest: "/tmp/{{ ojs_tarball }}"
+    checksum: "md5:{{ ojs_md5sum }}"
+
+- name: Download  OJS Bootstrap Theme tarball
+  get_url:
+    url: "{{ ojs_bootstrap_url }}{{ ojs_bootstrap_tarball }}"
+    dest: "/tmp/{{ ojs_bootstrap_tarball }}"
+    checksum: "md5:{{ ojs_bootstrap_md5sum }}"
+

--- a/tasks/upgrade.yml
+++ b/tasks/upgrade.yml
@@ -1,0 +1,37 @@
+---
+# Run OJS Upgrade Tools and DB Scripts
+
+- name: Mark the site as uninstalled in config.inc.php
+  replace:
+    dest: "/srv/journals.shareok.org/sites/{{ item.1.path }}/etc/config.inc.php"
+    regexp: >
+      ^installed = On$
+    replace: "installed = Off\n"
+  with_subelements:
+   - "{{ ojs_sites }}"
+   - installs
+  tags: mark_unsafe
+ 
+
+- name: Run PHP Upgrade Utility
+  shell: "{{sclphp_location}} /srv/journals.shareok.org/sites/{{ item.1.path }}/ojs/tools/upgrade.php upgrade"
+  with_subelements:
+   - "{{ ojs_sites }}"
+   - installs
+  tags: php_upgrade
+
+- name: Mark the site as installed in config.inc.php
+  replace:
+    dest: "/srv/journals.shareok.org/sites/{{ item.1.path }}/etc/config.inc.php"
+    regexp: >
+      ^installed = Off$
+    replace: "installed = On\n"
+  with_subelements:
+   - "{{ ojs_sites }}"
+   - installs
+  tags: mark_safe
+
+- name: Restart PHP
+  systemd:
+    state: restarted
+    name: "{{ sclphp_version }}-php-fpm"


### PR DESCRIPTION
I have tested this a few times on a copy of OJS3-Upgrade VM; these changes update the default vars to include the latest version(s) of Bootstrap3, OJS 3.2, and SCLPHP7.2.

The SCLPHP var is defined, but will only be used if the SCLPHP role is also applied. 

I also included an optional "Upgrade" tag which will upgrade an existing installation. 